### PR TITLE
Move version number to variable

### DIFF
--- a/bin/grin-setup.lua
+++ b/bin/grin-setup.lua
@@ -1,8 +1,8 @@
 local grinDir = shell.resolve("/"..fs.combine(fs.getDir(shell.getRunningProgram()), ".."))
 
 local grinPackagePath = "/" .. fs.combine(grinDir, "packages/Team-CC-Corp/Grin/")
-local grinInstallPath = "/" .. fs.combine(grinPackagePath, "1.2.4")
-shell.run("pastebin", "run", "VuBNx3va", "-u", "Team-CC-Corp", "-r", "Grin", "-t", "1.2.4", grinInstallPath)
+local grinInstallPath = "/" .. fs.combine(grinPackagePath, "@GRIN_VERSION@")
+shell.run("pastebin", "run", "VuBNx3va", "-u", "Team-CC-Corp", "-r", "Grin", "-t", "@GRIN_VERSION@", grinInstallPath)
 local githubApiResponse = assert(http.get("https://api.github.com/repos/Team-CC-Corp/Grin/releases"))
 assert(githubApiResponse.getResponseCode() == 200, "Failed github response")
 local fh = fs.open(fs.combine(grinPackagePath, "releases.json"), "w")

--- a/bin/grin-startup.lua
+++ b/bin/grin-startup.lua
@@ -8,7 +8,7 @@ assert(os.loadAPI(fs.combine(grinDir, "lib/grin")), "Failed to load Grin API")
 if json then
     os.unloadAPI("json")
 end
-local jsonAPIPath = grin.combine(grinDir, "packages/Team-CC-Corp/Grin/1.2.3/lib/json")
+local jsonAPIPath = grin.combine(grinDir, "packages/Team-CC-Corp/Grin/@GRIN_VERSION@/lib/json")
 assert(os.loadAPI(jsonAPIPath), "Failed to load JSON API") -- grin requires a minimum of the json API
 
 grin.setGrinDir(grinDir)

--- a/build.xml
+++ b/build.xml
@@ -9,6 +9,9 @@
     <target name="make_archive">
         <copy todir="build/grin/bin">
             <fileset dir="bin" />
+            <filterset>
+                <filter token="GRIN_VERSION" value="1.2.4" />
+            </filterset>
         </copy>
         <copy todir="build/grin/lib">
             <fileset dir="lib" />

--- a/lib/grin
+++ b/lib/grin
@@ -211,6 +211,7 @@ function getReleaseInfo(pkg)
 
     local jsonFh = assert(fs.open(combine(packageDir, "releases.json"), "r"), pkg.." releases.json not found", 2)
     local jsonData = json.decode(jsonFh.readAll())
+    jsonFh.close()
 
     return jsonData
 end

--- a/lib/grin
+++ b/lib/grin
@@ -223,10 +223,22 @@ function getReleaseInfoFromGithub(pkg)
     local githubApiResponse = assert(http.get("https://api.github.com/repos/"..user.."/"..repo.."/releases"))
     assert(githubApiResponse.getResponseCode() == 200, "Failed github response", 2)
     local jsonStr = githubApiResponse.readAll()
+
+    local decoded = json.decode(jsonStr)
+    for k, v in ipairs(decoded) do
+        decoded[k] = {
+            tag_name = v.tag_name,
+            target_commitish = v.target_commitish,
+            name = v.name,
+            published_at = v.published_at,
+        }
+    end
+
     local jsonFh = fs.open(combine(grinDir, "packages", user, repo, "releases.json"), "w")
-    jsonFh.write(jsonStr)
+    jsonFh.write(json.encode(decoded))
     jsonFh.close()
-    return json.decode(jsonStr)
+
+    return decoded
 end
 
 function getLatestInstalledVersion(pkg)


### PR DESCRIPTION
Prevents version numbers getting out of sync. Also close a file handle which wasn't.

You might need to bump the version number if my Grin PR gets merged.
